### PR TITLE
fix typo and mistranslation (誤字誤訳修正)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2001,7 +2001,7 @@ Other Style Guides
 
     // 'type' is ignored even if unused because it has a rest property sibling.
     // This is a form of extracting an object that omits the specified keys.
-    // 'type'はrestプロパティを隣に持つため、未使用でも無視されます。
+    // 残りのプロパティがあるため、'type' は未使用でも無視されます。
     // これは、指定されたキーを省略したオブジェクトを抽出する形式です。
     var { type, ...coords } = data;
     // 'coords' is now the 'data' object without its 'type' property.
@@ -3037,7 +3037,7 @@ Other Style Guides
 
   <a name="whitespace--computed-property-spacing"></a>
   - [19.15](#whitespace--computed-property-spacing) Enforce spacing inside of computed property brackets. eslint: [`computed-property-spacing`](https://eslint.org/docs/rules/computed-property-spacing)
-  - [19.15](#whitespace--computed-property-spacing) 計算用プロパティの括弧の中のスペースを強制する。eslint: [`computed-property-spacing`](https://eslint.org/docs/rules/computed-property-spacing)
+  - [19.15](#whitespace--computed-property-spacing) 計算プロパティの括弧の中にスペースは入れないこと。eslint: [`computed-property-spacing`](https://eslint.org/docs/rules/computed-property-spacing)
 
     ```javascript
     // bad


### PR DESCRIPTION
13.8: サンプルコード中のコメントの誤訳を修正
19.15: 誤訳修正

19.15 は翻訳元によると

> Enforce is correct; we’re enforcing “no spaces”.

だそうです。（https://github.com/airbnb/javascript/pull/1946#discussion_r229344251 ）


npmが無い環境なのでtestできていませんが、フォーマットは変更が無いので問題は無いと思われます。

よろしくお願いします。